### PR TITLE
WIP: Add .coafile & .travis.yml to lint **.yang & **.js

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,17 @@
+[javascript]
+bears = ESLintBear, JSHintBear #, HappinessLintBear
+eslint_config = .eslintrc
+jshint_config = .jshintrc
+files = models/**.js
+
+[json]
+bears = JSONFormatBear
+files = .eslintrc
+
+[yaml]
+bears = YAMLLintBear
+files = .travis.yml
+
+# [yang]
+# bears = YANGBear
+# files = models/**.yang

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+    "extends": "eslint:recommended",
+    "rules": {
+        "no-console": 0,
+        "no-redeclare": 0,
+        "no-undef": 0
+    }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,7 @@
+{
+    "shadow": true,
+    "sub": true,
+
+    "undef": true,
+    "predef": ["console", "module", "require"]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+
+language: python
+python:
+  - '3.6'
+
+env:
+  - NODE_JS_VERSION="7.5"
+
+install:
+  - nvm install $NODE_JS_VERSION
+  - npm install -g eslint jshint
+
+  - pip install git+https://github.com/coala/coala-bears.git@zimmermann/yang
+
+script:
+  - coala --ci --disable-caching


### PR DESCRIPTION
To start with Continuous Integration testing I activated Travis for this repository:

https://travis-ci.org/OpenNetworkingFoundation/CENTENNIAL

And as a first testing step I added [coala.io](https://coala.io) based static code analysis of all `*.yang` files under `models/` and its sub-directories.

**coala** doesn't support YANG linting yet. So I created a pull request for a `YANGBear`:

https://github.com/coala/coala-bears/pull/1428

And the Travis test script installs `coala-bears` directly from my related branch. So until it gets merged and included in the next `coala-bears` release, this CENTENNIAL pull request should stay WIP (Work In Progress).

I also activated required reviews and CI passing checks for pull requests to the **master** branch, so that the **master** branch stays clean and stable, as long as we follow a pull request based development process :)
